### PR TITLE
Fix hyperlanes not rotating in screenshots

### DIFF
--- a/projects/conclave/src/main/conclave/view/common.cljs
+++ b/projects/conclave/src/main/conclave/view/common.cljs
@@ -69,11 +69,13 @@
      [:div sub]]))
 
 (def clipped-hex-path "polygon(26% 2%, 74% 2%, 98% 50%, 74% 98%, 26% 98%, 2% 50%)")
-(def rotations {1 "rotate-60"
-                2 "rotate-120"
-                3 "rotate-180"
-                4 "rotate-240"
-                5 "rotate-300"})
+(def rotation-degrees {1 60
+                       2 120
+                       3 180
+                       4 240
+                       5 300})
+(defn rotations [rotation-level]
+  (str "rotate-" (rotation-degrees rotation-level)))
 
 (defn side->hex-dimension
   ([side] (side->hex-dimension side 1))
@@ -162,7 +164,7 @@
         off-label])
      [:span {:class ["relative" "inline-block" "p-0.5" "w-12" "h-6"
                      "border-2" "rounded-full" "border-gray-300"
-                     (if (or off-label on?) "bg-blue-900" "bg-gray-600") 
+                     (if (or off-label on?) "bg-blue-900" "bg-gray-600")
                      (if disabled "cursor-not-allowed" "cursor-pointer")
                      (when disabled "opacity-30")]
              :on-click (->dispatch-fn props)}

--- a/projects/conclave/src/main/conclave/view/sidebar/screenshot.cljs
+++ b/projects/conclave/src/main/conclave/view/sidebar/screenshot.cljs
@@ -30,9 +30,10 @@
     [:img {:key (apply str "img" coordinate)
            :src (str "images/" (tile/image tile))
            :width (* scale 2)
-           :class [(common/rotations rotation) "absolute"]
+           :class ["absolute"]
            :style {:clip-path common/clipped-hex-path
-                   :transform (translate-string scale coordinate)}}]))
+                   :transform (str (translate-string scale coordinate) " "
+                                   (when rotation (str "rotate(" (common/rotation-degrees rotation) "deg)")))}}]))
 
 (defn hidden-component-mounted [map-index element]
   (let [filename (str "conclave-" map-index ".jpg")]


### PR DESCRIPTION
The problem was that the tailwind css class `rotate-...` uses the `transform: rotate(...)` css property, which was being overridden by an inline style. The fix is just to add the proper `rotate` instruction to the inline `transform` style.

My clojure is no good, so please feel free to make any changes to the code! 

Closes #5 